### PR TITLE
Set graphics to vnc

### DIFF
--- a/templates/vms/debian/11/debian_vm_template.yml
+++ b/templates/vms/debian/11/debian_vm_template.yml
@@ -41,7 +41,7 @@ virt_install_import:
   os_type: Linux
   os_variant: debian10
   network: "{{ vm.network | default('network:default') }}"
-  graphics: spice
+  graphics: vnc
   memory: "{{ vm.memory | default(4096) }}"
   vcpu: "{{ vm.cpus | default(2) }}"
   disks:

--- a/templates/vms/debian/12/debian_vm_template.yml
+++ b/templates/vms/debian/12/debian_vm_template.yml
@@ -41,7 +41,7 @@ virt_install_import:
   os_type: Linux
   os_variant: debian10
   network: "{{ vm.network | default('network:default') }}"
-  graphics: spice
+  graphics: vnc
   memory: "{{ vm.memory | default(4096) }}"
   vcpu: "{{ vm.cpus | default(2) }}"
   disks:


### PR DESCRIPTION
* Set graphics to vnc, this allows the installation without that virt-viewer is installed.